### PR TITLE
Add an option to make to choose buidling static or shared library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,11 @@ artifacts/
 *.svclog
 *.scc
 *.a
+*.la
+*.so
+*.so.*
+*.dll
+*.dylib
 
 # Chutzpah Test files
 _Chutzpah*

--- a/FourQ_64bit_and_portable/makefile
+++ b/FourQ_64bit_and_portable/makefile
@@ -6,134 +6,125 @@ CC=gcc
 ARCH=x64
 ASM=TRUE
 AVX2=TRUE
-STATIC_LIB=TRUE
+SHARED_LIB_O=libFourQ.so
+STATIC_LIB_O=libFourQ.a
+POSITION_INDEPENDENT_CODE=-fPIC
 
 ifeq "$(CC)" "gcc"
-    COMPILER=gcc
+	COMPILER=gcc
 else ifeq "$(CC)" "clang"
-    COMPILER=clang
+	COMPILER=clang
 endif
 
 ifeq "$(ARCH)" "x64"
-    ARCHITECTURE=_AMD64_
+	ARCHITECTURE=_AMD64_
 ifeq "$(GENERIC)" "TRUE"
-    USE_GENERIC=-D _GENERIC_
+	USE_GENERIC=-D _GENERIC_
 endif
 ifeq "$(ASM)" "FALSE"
 else ifeq "$(ASM)" "TRUE"
-    USE_ASM=-D _ASM_
-    ASM_var=yes
+	USE_ASM=-D _ASM_
+	ASM_var=yes
 else
 ifneq "$(GENERIC)" "TRUE"
-    USE_ASM=-D _ASM_
-    ASM_var=yes
+	USE_ASM=-D _ASM_
+	ASM_var=yes
 endif
 endif
 ifeq "$(AVX)" "FALSE"
 else ifeq "$(AVX)" "TRUE"
-    USE_AVX=-D _AVX_
-    SIMD=-mavx
+	USE_AVX=-D _AVX_
+	SIMD=-mavx
 else
 ifneq "$(GENERIC)" "TRUE"
-    USE_AVX=-D _AVX_
-    SIMD=-mavx
-endif  	
+	USE_AVX=-D _AVX_
+	SIMD=-mavx
+endif
 endif
 ifeq "$(AVX2)" "FALSE"
 else ifeq "$(AVX2)" "TRUE"
-    USE_AVX2=-D _AVX2_
-    SIMD=-mavx2
-    AVX2_var=yes
+	USE_AVX2=-D _AVX2_
+	SIMD=-mavx2
+	AVX2_var=yes
 else
 ifneq "$(GENERIC)" "TRUE"
-    USE_AVX2=-D _AVX2_
-    SIMD=-mavx2
-    AVX2_var=yes
-endif  	
+	USE_AVX2=-D _AVX2_
+	SIMD=-mavx2
+	AVX2_var=yes
+endif
 endif
 
 else ifeq "$(ARCH)" "ARM64"
-    ARCHITECTURE=_ARM64_
-    ARM_SETTING=-lrt
+	ARCHITECTURE=_ARM64_
+	ARM_SETTING=-lrt
 ifeq "$(GENERIC)" "TRUE"
-    USE_GENERIC=-D _GENERIC_
+	USE_GENERIC=-D _GENERIC_
 endif
 
 else
 
 USE_GENERIC=-D _GENERIC_
 ifeq "$(GENERIC)" "FALSE"
-    USE_GENERIC=
+	USE_GENERIC=
 endif
 ifeq "$(ASM)" "TRUE"
-    USE_ASM=-D _ASM_
+	USE_ASM=-D _ASM_
 endif
 ifeq "$(AVX)" "TRUE"
-    USE_ASM=-D _ASM_
+	USE_ASM=-D _ASM_
 endif
 ifeq "$(AVX2)" "TRUE"
-    USE_ASM=-D _ASM_
+	USE_ASM=-D _ASM_
 endif
 ifeq "$(ARCH)" "x86"
-    ARCHITECTURE=_X86_
+	ARCHITECTURE=_X86_
 else ifeq "$(ARCH)" "ARM"
-    ARCHITECTURE=_ARM_
-    ARM_SETTING=-lrt
+	ARCHITECTURE=_ARM_
+	ARM_SETTING=-lrt
 endif
 endif
 
 ADDITIONAL_SETTINGS=-fwrapv -fomit-frame-pointer -march=native
 ifeq "$(EXTENDED_SET)" "FALSE"
-    ADDITIONAL_SETTINGS=
+	ADDITIONAL_SETTINGS=
 endif
 
 USE_ENDOMORPHISMS=-D USE_ENDO
 ifeq "$(USE_ENDO)" "FALSE"
-    USE_ENDOMORPHISMS=
+	USE_ENDOMORPHISMS=
 endif
 
 ifeq "$(SERIAL_PUSH)" "TRUE"
-    USE_SERIAL_PUSH=-D PUSH_SET
-endif
-
-SHARED_LIB_TARGET=libFourQ.so
-ifeq "$(SHARED_LIB)" "TRUE"
-    DO_MAKE_SHARED_LIB=-fPIC
-	SHARED_LIB_O=$(SHARED_LIB_TARGET)
-endif
-
-STATIC_LIBRARY_TARGET=libFourQ.a
-ifeq "$(STATIC_LIB)" "TRUE"
-    STATIC_LIB_O=$(STATIC_LIBRARY_TARGET)
+	USE_SERIAL_PUSH=-D PUSH_SET
 endif
 
 cc=$(COMPILER)
-CFLAGS=-c $(OPT) $(ADDITIONAL_SETTINGS) $(SIMD) -D $(ARCHITECTURE) -D __LINUX__ $(USE_AVX) $(USE_AVX2) $(USE_ASM) $(USE_GENERIC) $(USE_ENDOMORPHISMS) $(USE_SERIAL_PUSH) $(DO_MAKE_SHARED_LIB)
+CFLAGS=-c $(OPT) $(ADDITIONAL_SETTINGS) $(SIMD) -D $(ARCHITECTURE) -D __LINUX__ $(USE_AVX) $(USE_AVX2) $(USE_ASM) $(USE_GENERIC) $(USE_ENDOMORPHISMS) $(USE_SERIAL_PUSH) $(POSITION_INDEPENDENT_CODE)
 LDFLAGS=
 ifdef ASM_var
 ifdef AVX2_var
-    ASM_OBJECTS=fp2_1271_AVX2.o
+	ASM_OBJECTS=fp2_1271_AVX2.o
 else
-    ASM_OBJECTS=fp2_1271.o
-endif 
+	ASM_OBJECTS=fp2_1271.o
 endif
-OBJECTS=eccp2.o eccp2_no_endo.o eccp2_core.o $(ASM_OBJECTS) crypto_util.o schnorrq.o kex.o sha512.o random.o 
-OBJECTS_FP_TEST=fp_tests.o $(OBJECTS) test_extras.o 
-OBJECTS_ECC_TEST=ecc_tests.o $(OBJECTS) test_extras.o 
-OBJECTS_CRYPTO_TEST=crypto_tests.o $(OBJECTS) test_extras.o 
+endif
+OBJECTS=eccp2.o eccp2_no_endo.o eccp2_core.o $(ASM_OBJECTS) crypto_util.o schnorrq.o kex.o sha512.o random.o
+OBJECTS_FP_TEST=fp_tests.o $(OBJECTS) test_extras.o
+OBJECTS_ECC_TEST=ecc_tests.o $(OBJECTS) test_extras.o
+OBJECTS_CRYPTO_TEST=crypto_tests.o $(OBJECTS) test_extras.o
 OBJECTS_ALL=$(OBJECTS) $(OBJECTS_FP_TEST) $(OBJECTS_ECC_TEST) $(OBJECTS_CRYPTO_TEST)
 
-all: crypto_test ecc_test fp_test $(SHARED_LIB_O) $(STATIC_LIB_O)
+all: crypto_test ecc_test fp_test static shared
 
-ifeq "$(SHARED_LIB)" "TRUE"
-    $(SHARED_LIB_O): $(OBJECTS)
-	    $(CC) -shared -o $(SHARED_LIB_O) $(OBJECTS)
-endif
+static: $(STATIC_LIB_O)
 
-ifeq "$(STATIC_LIB)" "TRUE"
-    $(STATIC_LIB_O): $(OBJECTS)
+shared: $(SHARED_LIB_O)
+
+$(STATIC_LIB_O): $(OBJECTS)
 	ar rcs $(STATIC_LIB_O) $(OBJECTS)
-endif
+
+$(SHARED_LIB_O): $(OBJECTS)
+	$(CC) -shared -o $(SHARED_LIB_O) $(OBJECTS)
 
 crypto_test: $(OBJECTS_CRYPTO_TEST)
 	$(CC) -o crypto_test $(OBJECTS_CRYPTO_TEST) $(ARM_SETTING)
@@ -152,17 +143,17 @@ eccp2.o: eccp2.c
 
 eccp2_no_endo.o: eccp2_no_endo.c
 	$(CC) $(CFLAGS) eccp2_no_endo.c
-    
+
 ifdef ASM_var
 ifdef AVX2_var
-    AMD64/consts.s: AMD64/consts.c
-	    $(CC) $(CFLAGS) -S -o $@ $<
-	    sed '/.globl/d' -i $@
-    fp2_1271_AVX2.o: AMD64/fp2_1271_AVX2.S AMD64/consts.s
-	    $(CC) $(CFLAGS) -o $@ $<
+AMD64/consts.s: AMD64/consts.c
+	$(CC) $(CFLAGS) -S -o $@ $<
+	sed '/.globl/d' -i $@
+fp2_1271_AVX2.o: AMD64/fp2_1271_AVX2.S AMD64/consts.s
+	$(CC) $(CFLAGS) -o $@ $<
 else
-    fp2_1271.o: AMD64/fp2_1271.S
-	    $(CC) $(CFLAGS) AMD64/fp2_1271.S
+fp2_1271.o: AMD64/fp2_1271.S
+	$(CC) $(CFLAGS) AMD64/fp2_1271.S
 endif
 endif
 


### PR DESCRIPTION
- Static library will now be built with `-fPIC`.
- `make static` builds a static library.
- `make shared` builds a shared library.
- `make` builds both libraries.
- Converted indentations from spaces to tabs (Makefile rules).